### PR TITLE
[OPAL-5489] update terraformer to allow importing on_call_schedule(s) and reviewer_stage(s)

### DIFF
--- a/docs/opal.md
+++ b/docs/opal.md
@@ -68,3 +68,7 @@ $ terraform plan # No changes. Your infrastructure matches the configuration.
     * `opal_resource`
 *   `group`
     * `opal_group`
+*   `on_call_schedules`
+    * `opal_on_call_schedules`
+*   `message_channels`
+    * `opal_message_channels`

--- a/go.mod
+++ b/go.mod
@@ -349,6 +349,7 @@ require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.1.0
 	github.com/Myra-Security-GmbH/myrasec-go/v2 v2.19.0
 	github.com/manicminer/hamilton v0.44.0
+	github.com/opalsecurity/opal-go v1.0.19
 	gopkg.in/ns1/ns1-go.v2 v2.6.5
 )
 
@@ -369,7 +370,6 @@ require (
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/manicminer/hamilton-autorest v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/opalsecurity/opal-go v1.0.9 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1172,12 +1172,8 @@ github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je4
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/opalsecurity/opal-go v1.0.5 h1:ZDS6FYzUnbjRhnRx+TreTsSxtPdWjLDI4RpSQrbEUgM=
-github.com/opalsecurity/opal-go v1.0.5/go.mod h1:bzD4vZIbH+lKhsX8NJ5ISNU2Xgm2qzjj6O9G2ycj58c=
-github.com/opalsecurity/opal-go v1.0.8 h1:3o1qElrwZR+O1ma8YdaZbYYnzxxOsKQh0/2sWDJ7Idk=
-github.com/opalsecurity/opal-go v1.0.8/go.mod h1:bzD4vZIbH+lKhsX8NJ5ISNU2Xgm2qzjj6O9G2ycj58c=
-github.com/opalsecurity/opal-go v1.0.9 h1:NlP3K15cpEYwtwHMnpp9TbzaLILUtcTm+OQax0a8p88=
-github.com/opalsecurity/opal-go v1.0.9/go.mod h1:bzD4vZIbH+lKhsX8NJ5ISNU2Xgm2qzjj6O9G2ycj58c=
+github.com/opalsecurity/opal-go v1.0.19 h1:w9JPghoq9ks3/Br/KC/9h8jiJVlY3JJ/k/imq/pMVd8=
+github.com/opalsecurity/opal-go v1.0.19/go.mod h1:G7QQIi36kI3kiTl/Dp8AvLDNoui9jqFOSUthcZ0aof4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=

--- a/providers/opal/on_call_schedule.go
+++ b/providers/opal/on_call_schedule.go
@@ -1,0 +1,46 @@
+package opal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+type OnCallScheduleGenerator struct {
+	OpalService
+}
+
+func (g *OnCallScheduleGenerator) InitResources() error {
+	client, err := g.newClient()
+	if err != nil {
+		return fmt.Errorf("unable to list opal on call schedules: %v", err)
+	}
+
+	onCallSchedules, _, err := client.OnCallSchedulesApi.GetOnCallSchedules(context.TODO()).Execute()
+	if err != nil {
+		return fmt.Errorf("unable to list opal on call schedules: %v", err)
+	}
+
+	countByName := make(map[string]int)
+
+	for _, onCallSchedule := range onCallSchedules.OnCallSchedules {
+		name := normalizeResourceName(*onCallSchedule.Name)
+		if count, ok := countByName[name]; ok {
+			countByName[name] = count + 1
+			name = normalizeResourceName(fmt.Sprintf("%s_%d", *onCallSchedule.Name, count+1))
+		} else {
+			countByName[name] = 1
+		}
+
+		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			*onCallSchedule.OnCallScheduleId,
+			name,
+			"opal_on_call_schedule",
+			"opal",
+			[]string{},
+		))
+	}
+
+	return nil
+}

--- a/providers/opal/opal_provider.go
+++ b/providers/opal/opal_provider.go
@@ -53,18 +53,21 @@ func (p OpalProvider) GetResourceConnections() map[string]map[string][]string {
 		"resource": {
 			"owner": {
 				"admin_owner_id", "id",
-				"reviewer.id", "id",
+				"reviewer_stage.reviewer.id", "id",
 			},
 			"group": {"visibility_group.id", "id"},
 		},
 		"group": {
 			"owner": {
 				"admin_owner_id", "id",
-				"reviewer.id", "id",
+				"reviewer_stage.reviewer.id", "id",
 			},
 			"group": {"visibility_group.id", "id"},
 			"message_channel": {
 				"audit_message_channel.id", "id",
+			},
+			"on_call_schedule": {
+				"on_call_schedule.id", "id",
 			},
 		},
 		"owner": {
@@ -113,9 +116,10 @@ func (p *OpalProvider) InitService(serviceName string, verbose bool) error {
 
 func (p *OpalProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
-		"owner":           &OwnerGenerator{},
-		"resource":        &ResourceGenerator{},
-		"group":           &GroupGenerator{},
-		"message_channel": &MessageChannelGenerator{},
+		"owner":            &OwnerGenerator{},
+		"resource":         &ResourceGenerator{},
+		"group":            &GroupGenerator{},
+		"message_channel":  &MessageChannelGenerator{},
+		"on_call_schedule": &OnCallScheduleGenerator{},
 	}
 }


### PR DESCRIPTION
Example: 
```tf
resource "opal_group" "tfer--api_group" {
  admin_owner_id = "${data.terraform_remote_state.local.outputs.opal_owner_tfer--api_owner_id}"
  app_id         = "0caea4bf-8502-47cc-a2bf-759a147e77ff"
  auto_approval  = "false"
  description    = "This group is extremely sensitive. Used for team leads and senior engineers who need to touch API infrastructure in prod."
  group_type     = "OPAL_GROUP"
  is_requestable = "true"
  max_duration   = "0"
  name           = "API Group"

  on_call_schedule {
    id = "${data.terraform_remote_state.local.outputs.opal_on_call_schedule_tfer--alwaysandri2_id}"
  }

  on_call_schedule {
    id = "${data.terraform_remote_state.local.outputs.opal_on_call_schedule_tfer--test_schedule_id}"
  }

  recommended_duration   = "0"
  require_mfa_to_approve = "false"
  require_mfa_to_request = "false"
  require_support_ticket = "false"

  reviewer_stage {
    operator                 = "AND"
    require_manager_approval = "false"

    reviewer {
      id = "${data.terraform_remote_state.local.outputs.opal_owner_tfer--api_owner_id}"
    }
  }

  reviewer_stage {
    operator                 = "AND"
    require_manager_approval = "true"

    reviewer {
      id = "${data.terraform_remote_state.local.outputs.opal_owner_tfer--integrations_owner_id}"
    }
  }

  visibility = "LIMITED"
}
```

Tested with:
```
../terraformer/terraformer-opal import opal --resources="*" --path-pattern {output}/{provider}
terraform state replace-provider -auto-approve "registry.terraform.io/-/opal" "opalsecurity/opal"
cd generated/opal
terraform apply
```
output:
```
<omitted>
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
<omitted>
```